### PR TITLE
create: remove `async`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,120 +3,154 @@ import * as os from "os";
 import * as path from "path";
 
 export class PasswordStore {
-    private kbpgp: any;
-    private keyManager: any;
-    private passwordStoreDir: string;
+  private kbpgp: any;
+  private keyManager: any;
+  private passwordStoreDir: string;
 
-    private constructor(private privateKeyFile: string, passwordStoreDir?: string) {
-        this.kbpgp = require("kbpgp");
-        this.passwordStoreDir = passwordStoreDir ?? path.join(os.homedir(), ".password-store");
-    }
+  private constructor(
+    private privateKeyFile: string,
+    passwordStoreDir?: string
+  ) {
+    this.kbpgp = require("kbpgp");
+    this.passwordStoreDir =
+      passwordStoreDir ?? path.join(os.homedir(), ".password-store");
+  }
 
-    public static async create(privateKeyFile: string, passwordStoreDir?: string): Promise<PasswordStore> {
-        // TODO Prompt for private key passphrase?
-        const instance = new PasswordStore(privateKeyFile, passwordStoreDir);
-        if (fs.existsSync(instance.privateKeyFile)) {
-            return new Promise((resolve, reject) => {
-                instance.kbpgp.KeyManager.import_from_armored_pgp({
-                    armored: fs.readFileSync(instance.privateKeyFile, "utf-8")
-                }, (err: Error | null, key: any) => {
-                    if (err) return reject(err);
-                    instance.keyManager = key;
-                    resolve(instance);
-                });
-            });
-        } else {
-            return new Promise((resolve, reject) => {
-                instance.kbpgp.KeyManager.generate_rsa({
-                    userid: os.userInfo().username
-                }, (err: Error | null, key: any) => {
-                    if (err) return reject(err);
-                    instance.keyManager = key;
-                    key.sign({}, (err: Error | null) => {
-                        if (err) return reject(err);
-                        key.export_pgp_private({}, (err: Error | null, pgpPrivate: string) => {
-                            if (err) return reject(err);
-                            fs.writeFileSync(instance.privateKeyFile, pgpPrivate, { mode: 0o600 });
-                            key.export_pgp_public({}, (err: Error | null, pgpPublic: string) => {
-                                if (err) return reject(err);
-                                fs.writeFileSync(instance.privateKeyFile + ".pub", pgpPublic, { mode: 0o644 });
-                                resolve(instance);
-                            });
-                        });
-                    });
-                });
-            });
+  public static create(
+    privateKeyFile: string,
+    passwordStoreDir?: string
+  ): PasswordStore {
+    // TODO Prompt for private key passphrase?
+    const instance = new PasswordStore(privateKeyFile, passwordStoreDir);
+    if (fs.existsSync(instance.privateKeyFile)) {
+      instance.kbpgp.KeyManager.import_from_armored_pgp(
+        {
+          armored: fs.readFileSync(instance.privateKeyFile, "utf-8"),
+        },
+        (err: Error | null, key: any) => {
+          if (err) return null;
+          instance.keyManager = key;
         }
-    }
-
-    public getPassword(service: string, account: string): Promise<string | null> {
-        const passwordFile = path.join(this.passwordStoreDir, service, account) + ".gpg";
-        if (fs.existsSync(passwordFile)) {
-            const ring = new this.kbpgp.keyring.KeyRing();
-            ring.add_key_manager(this.keyManager);
-            return new Promise((resolve, reject) => {
-                this.kbpgp.unbox(
-                    { keyfetch: ring, raw: fs.readFileSync(passwordFile) },
-                    (err: Error | null, literals: any) => {
-                        if (err) return reject(err);
-                        resolve(literals[0].toString().slice(0, -1));
-                    }
+      );
+    } else {
+      instance.kbpgp.KeyManager.generate_rsa(
+        {
+          userid: os.userInfo().username,
+        },
+        (err: Error | null, key: any) => {
+          if (err) return null;
+          instance.keyManager = key;
+          key.sign({}, (err: Error | null) => {
+            if (err) return null;
+            key.export_pgp_private(
+              {},
+              (err: Error | null, pgpPrivate: string) => {
+                if (err) return null;
+                fs.writeFileSync(instance.privateKeyFile, pgpPrivate, {
+                  mode: 0o600,
+                });
+                key.export_pgp_public(
+                  {},
+                  (err: Error | null, pgpPublic: string) => {
+                    if (err) return null;
+                    fs.writeFileSync(
+                      instance.privateKeyFile + ".pub",
+                      pgpPublic,
+                      { mode: 0o644 }
+                    );
+                  }
                 );
-            });
-        } else {
-            return Promise.resolve(null);
+              }
+            );
+          });
         }
+      );
     }
 
-    public setPassword(service: string, account: string, password: string): Promise<void> {
-        const passwordFile = path.join(this.passwordStoreDir, service, account) + ".gpg";
-        fs.mkdirSync(path.dirname(passwordFile), { mode: 0o700, recursive: true });
-        return new Promise((resolve, reject) => {
-            this.kbpgp.box({
-                msg: Buffer.from(password + "\n"),
-                encrypt_for: this.keyManager
-            }, (err: Error | null, _: string, result: Buffer) => {
-                if (err) return reject(err);
-                resolve(fs.writeFileSync(passwordFile, result, { mode: 0o600 }));
-            });
-        });
-    }
+    return instance;
+  }
 
-    public deletePassword(service: string, account: string): Promise<boolean> {
-        // TODO Verify key before deletion?
-        const passwordFile = path.join(this.passwordStoreDir, service, account) + ".gpg";
-        if (fs.existsSync(passwordFile)) {
-            return new Promise((resolve, reject) => {
-                fs.rm(passwordFile, (err: Error | null) => {
-                    if (err) return reject(err);
-                    resolve(true);
-                })
-            });
-        } else {
-            return Promise.resolve(false);
+  public getPassword(service: string, account: string): Promise<string | null> {
+    const passwordFile =
+      path.join(this.passwordStoreDir, service, account) + ".gpg";
+    if (fs.existsSync(passwordFile)) {
+      const ring = new this.kbpgp.keyring.KeyRing();
+      ring.add_key_manager(this.keyManager);
+      return new Promise((resolve, reject) => {
+        this.kbpgp.unbox(
+          { keyfetch: ring, raw: fs.readFileSync(passwordFile) },
+          (err: Error | null, literals: any) => {
+            if (err) return reject(err);
+            resolve(literals[0].toString().slice(0, -1));
+          }
+        );
+      });
+    } else {
+      return Promise.resolve(null);
+    }
+  }
+
+  public setPassword(
+    service: string,
+    account: string,
+    password: string
+  ): Promise<void> {
+    const passwordFile =
+      path.join(this.passwordStoreDir, service, account) + ".gpg";
+    fs.mkdirSync(path.dirname(passwordFile), { mode: 0o700, recursive: true });
+    return new Promise((resolve, reject) => {
+      this.kbpgp.box(
+        {
+          msg: Buffer.from(password + "\n"),
+          encrypt_for: this.keyManager,
+        },
+        (err: Error | null, _: string, result: Buffer) => {
+          if (err) return reject(err);
+          resolve(fs.writeFileSync(passwordFile, result, { mode: 0o600 }));
         }
-    }
+      );
+    });
+  }
 
-    public findCredentials(service: string): Promise<{ account: string; password: string }[]> {
-        const serviceDir = path.join(this.passwordStoreDir, service);
-        const credentials: { account: string; password: string }[] = [];
-        return new Promise((resolve, reject) => {
-            fs.readdir(serviceDir, (err: Error | null, files: string[]) => {
-                if (err) return reject(err);
-                Promise.all(files.filter((file) => file.endsWith(".gpg"))
-                    .map((file) => {
-                        const account = file.slice(0, -4);
-                        return this.getPassword(service, account)
-                            .then((password) => {
-                                if (password) credentials.push({ account, password });
-                            });
-                    })
-                ).then(() => resolve(credentials));
-            });
+  public deletePassword(service: string, account: string): Promise<boolean> {
+    // TODO Verify key before deletion?
+    const passwordFile =
+      path.join(this.passwordStoreDir, service, account) + ".gpg";
+    if (fs.existsSync(passwordFile)) {
+      return new Promise((resolve, reject) => {
+        fs.rm(passwordFile, (err: Error | null) => {
+          if (err) return reject(err);
+          resolve(true);
         });
+      });
+    } else {
+      return Promise.resolve(false);
     }
+  }
 
-    public findPassword(service: string): Promise<string | null> {
-        return this.getPassword("", service);
-    }
+  public findCredentials(
+    service: string
+  ): Promise<{ account: string; password: string }[]> {
+    const serviceDir = path.join(this.passwordStoreDir, service);
+    const credentials: { account: string; password: string }[] = [];
+    return new Promise((resolve, reject) => {
+      fs.readdir(serviceDir, (err: Error | null, files: string[]) => {
+        if (err) return reject(err);
+        Promise.all(
+          files
+            .filter((file) => file.endsWith(".gpg"))
+            .map((file) => {
+              const account = file.slice(0, -4);
+              return this.getPassword(service, account).then((password) => {
+                if (password) credentials.push({ account, password });
+              });
+            })
+        ).then(() => resolve(credentials));
+      });
+    });
+  }
+
+  public findPassword(service: string): Promise<string | null> {
+    return this.getPassword("", service);
+  }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,8 +3,8 @@ import { PasswordStore } from "../src";
 describe("password-store", () => {
     let passApi: PasswordStore;
 
-    beforeAll(async () => {
-        passApi = await PasswordStore.create("test.pgp", ".password-store");
+    beforeAll(() => {
+        passApi = PasswordStore.create("test.pgp", ".password-store");
     }, 60000);
 
     it("get/setPassword with ASCII string", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,11 +1,12 @@
 import { PasswordStore } from "../src";
 
+jest.setTimeout(60000);
 describe("password-store", () => {
     let passApi: PasswordStore;
 
-    beforeAll(() => {
-        passApi = PasswordStore.create("test.pgp", ".password-store");
-    }, 60000);
+    beforeEach(() => {
+        passApi = new PasswordStore("test.pgp", ".password-store");
+    });
 
     it("get/setPassword with ASCII string", async () => {
         await passApi.setPassword("TestKeytar", "TestASCII", "ASCII string");


### PR DESCRIPTION
Makes `PasswordStore::create` a synchronous function so that imports can be dynamically resolved for keytar-rs

Marked as draft until tests are fixed